### PR TITLE
Win64 overwrites previous correct detection of Windows 10

### DIFF
--- a/lib/HTML/ParseBrowser.pm
+++ b/lib/HTML/ParseBrowser.pm
@@ -197,9 +197,9 @@ sub Parse {
                 }
             }
             elsif (/Windows (?:Phone )?(\d+(\.\d+)?)/) {
-                $browser->{osvers} = $1;
+                $browser->{osvers} = $1 if !$browser->{osvers};
             } elsif (/Win(\w\w)/i) {
-                $browser->{osvers} = $1;
+                $browser->{osvers} = $1 if !$browser->{osvers};
             }
         }
 

--- a/t/corpus.json
+++ b/t/corpus.json
@@ -342,5 +342,13 @@
       "os":"iOS",
       "ostype":"iOS",
       "osvers":"10.0"
+    },
+    {
+      "user_agent":"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:77.0) Gecko/20100101 Firefox/77.0",
+      "name":"Firefox",
+      "major":"77",
+      "minor":"0",
+      "ostype":"Windows",
+      "osvers":"10"
     }
 ]


### PR DESCRIPTION
In this example User Agent String

Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:77.0) Gecko/20100101 Firefox/77.0

The OS Version is being reported as 64, due to the Win64 line being parsed and overwriting the previously parsed "Windows NT 10.0" section.

This prevents the "WinXX" part overwriting the version from the more reliable "Windows NT foo" part if it has already been set.